### PR TITLE
Improve music page layout and cover art handling

### DIFF
--- a/pages/music_page.py
+++ b/pages/music_page.py
@@ -4,7 +4,7 @@ from kivy.uix.button import Button
 from kivy.uix.modalview import ModalView
 from kivy.uix.recycleview import RecycleView
 from kivy.uix.recycleview.views import RecycleDataViewBehavior
-from kivy.uix.image import AsyncImage
+from ui.cover_image import CoverImage
 from kivy.properties import BooleanProperty
 from kivy.clock import Clock
 from kivy.graphics import Color, Rectangle, RoundedRectangle
@@ -301,14 +301,16 @@ class MusicPage(BoxLayout):
         self.now_playing_layout = BoxLayout(
             orientation='vertical',
             spacing=Theme.SPACING_MEDIUM,
-            padding=[0, Theme.PADDING_LARGE, 0, Theme.PADDING_LARGE]
+            padding=[0, Theme.PADDING_LARGE, 0, Theme.PADDING_LARGE],
+            size_hint_y=None
         )
+        self.now_playing_layout.bind(minimum_height=self.now_playing_layout.setter('height'))
 
-        # Cover art
-        self.cover_image = AsyncImage(
+        # Cover art with placeholder
+        self.cover_image = CoverImage(
             source='',
             size_hint=(1, None),
-            height=220,
+            height=300,
             allow_stretch=True,
         )
         self.now_playing_layout.add_widget(self.cover_image)
@@ -427,7 +429,9 @@ class MusicPage(BoxLayout):
             self.album_label.text = ""
 
         if art:
-            self.cover_image.source = art
+            self.cover_image.set_source(art)
+        else:
+            self.cover_image.set_source('')
     
     def on_page_enter(self):
         """Called when page becomes active"""

--- a/ui/cover_image.py
+++ b/ui/cover_image.py
@@ -1,0 +1,43 @@
+from kivy.uix.image import AsyncImage
+from kivy.graphics import Color, Rectangle
+
+from .theme import Theme
+
+
+class CoverImage(AsyncImage):
+    """AsyncImage that shows a gray square when no image is available."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        with self.canvas.before:
+            self._bg_color = Color(*Theme.PLACEHOLDER_COLOR)
+            self._bg_rect = Rectangle(pos=self.pos, size=self.size)
+        self.bind(pos=self._update_bg, size=self._update_bg,
+                   on_load=self._on_load, on_error=self._on_error)
+
+    def _update_bg(self, *args):
+        self._bg_rect.pos = self.pos
+        self._bg_rect.size = self.size
+
+    def _on_load(self, *args):
+        # Hide placeholder when an image is successfully loaded
+        if self.texture:
+            self._bg_color.a = 0
+        else:
+            self._bg_color.a = 1
+
+    def _on_error(self, *args):
+        # Show gray placeholder on load failure
+        self._bg_color.a = 1
+        self.texture = None
+
+    def set_source(self, src: str):
+        """Set the image source and reset placeholder state."""
+        if src:
+            self._bg_color.a = 0
+            self.source = src
+            self.reload()
+        else:
+            self.source = ''
+            self.texture = None
+            self._bg_color.a = 1

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -19,6 +19,8 @@ class Theme:
     SUCCESS_COLOR = (0.2, 0.7, 0.3, 1)
     WARNING_COLOR = (0.9, 0.6, 0.1, 1)
     ERROR_COLOR = (0.8, 0.2, 0.2, 1)
+    # Generic gray used for image placeholders
+    PLACEHOLDER_COLOR = (0.5, 0.5, 0.5, 1)
 
     # Active palette (defaults to light)
     BACKGROUND_COLOR = LIGHT_BACKGROUND


### PR DESCRIPTION
## Summary
- add placeholder color constant to Theme
- create CoverImage widget that shows gray square on failure
- use CoverImage on MusicPage and tweak layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cbd39c7a48330afffb3338bdc7595